### PR TITLE
Clear the store if sessionPresent is false on mqttv5

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1491,6 +1491,10 @@ MqttClient.prototype._onConnect = function (packet) {
 
   this.connected = true
 
+  if (this.options.protocolVersion === 5 && !packet.sessionPresent) {
+    that.outgoingStore.clear()
+  }
+
   function startStreamProcess () {
     var outStore = that.outgoingStore.createStream()
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -125,4 +125,15 @@ Store.prototype.close = function (cb) {
   }
 }
 
+/**
+ * Clear the store
+ */
+Store.prototype.clear = function (cb) {
+  this._inflights.clear()
+  if (cb) {
+    cb()
+  }
+  return this
+}
+
 module.exports = Store

--- a/test/abstract_store.js
+++ b/test/abstract_store.js
@@ -132,4 +132,29 @@ module.exports = function abstractStoreTest (build) {
       })
     })
   })
+
+  it('should clear in-flight packets', function (done) {
+    var packet1 = {
+      topic: 'hello',
+      payload: 'world',
+      qos: 1,
+      messageId: 42
+    }
+    var packet2 = {
+      cmd: 'pubrel',
+      qos: 2,
+      messageId: 43
+    }
+    store.put(packet1, function () {
+      store.put(packet2, function () {
+        store
+          .clear()
+          .createStream()
+          .on('data', function () {
+            done(new Error('this should never happen'))
+          })
+          .on('end', done)
+      })
+    })
+  })
 }

--- a/types/lib/store.d.ts
+++ b/types/lib/store.d.ts
@@ -42,5 +42,10 @@ declare class Store {
    * Close the store
    */
   public close (cb: Function): void
+
+  /**
+   * Clear the store
+   */
+  public clear (cb: Function): this
 }
 export { Store }


### PR DESCRIPTION
In MQTT V5, If the SessionState does not exist, the broker returns false to sessionPresent with CONNACK.
In this case, the client should not send a in-flight messages.

The MQTT V5.0 specification has the following description.  
OASIS : Session Expiry Interval https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901048
```
Non-normative comment

The Client can avoid implementing its own Session expiry and instead rely on the Session Present flag returned from the Server to determine if the Session had expired. If the Client does implement its own Session expiry, it needs to store the time at which the Session State will be deleted as part of its Session State.
```


I updated it as follows.

- Clear the store if sessionPresent is false, only for mqtt v5.
- Implemented clear function in store.js.
- Added test for in-flight messages.


Signed-off-by: ogis-yamazaki <Yamazaki_Shoji@ogis-ri.co.jp>